### PR TITLE
feat: expose modules on root level of `pharia-data-sdk`

### DIFF
--- a/pharia_data_sdk/__init__.py
+++ b/pharia_data_sdk/__init__.py
@@ -1,0 +1,21 @@
+from .connectors.data.data import DataClient as DataClient
+from .connectors.document_index.document_index import (
+    AsyncDocumentIndexClient as AsyncDocumentIndexClient,
+)
+from .connectors.document_index.document_index import (
+    DocumentIndexClient as DocumentIndexClient,
+)
+from .connectors.retrievers.document_index_retriever import (
+    AsyncDocumentIndexRetriever as AsyncDocumentIndexRetriever,
+)
+from .connectors.retrievers.document_index_retriever import (
+    DocumentIndexRetriever as DocumentIndexRetriever,
+)
+from .connectors.retrievers.hybrid_qdrant_in_memory_retriever import (
+    HybridQdrantInMemoryRetriever as HybridQdrantInMemoryRetriever,
+)
+from .connectors.retrievers.qdrant_in_memory_retriever import (
+    QdrantInMemoryRetriever as QdrantInMemoryRetriever,
+)
+
+__all__ = [symbol for symbol in dir() if symbol and symbol[0].isupper()]

--- a/pharia_data_sdk/connectors/__init__.py
+++ b/pharia_data_sdk/connectors/__init__.py
@@ -1,0 +1,85 @@
+from .data.data import DataClient as DataClient
+from .data.exceptions import (
+    DataExternalServiceUnavailable as DataExternalServiceUnavailable,
+)
+from .data.exceptions import (
+    DataForbiddenError as DataForbiddenError,
+)
+from .data.exceptions import (
+    DataInternalError as DataInternalError,
+)
+from .data.exceptions import (
+    DataInvalidInput as DataInvalidInput,
+)
+from .data.exceptions import (
+    DataResourceNotFound as DataResourceNotFound,
+)
+from .data.models import (
+    DataDataset as DataDataset,
+)
+from .data.models import (
+    DataFile as DataFile,
+)
+from .data.models import (
+    DataFileCreate as DataFileCreate,
+)
+from .data.models import (
+    DataRepository as DataRepository,
+)
+from .data.models import (
+    DataRepositoryCreate as DataRepositoryCreate,
+)
+from .data.models import (
+    DatasetCreate as DatasetCreate,
+)
+from .data.models import (
+    DataStage as DataStage,
+)
+from .data.models import (
+    DataStageCreate as DataStageCreate,
+)
+from .document_index.document_index import (
+    AsyncDocumentIndexClient as AsyncDocumentIndexClient,
+)
+from .document_index.document_index import CollectionPath as CollectionPath
+from .document_index.document_index import ConstraintViolation as ConstraintViolation
+from .document_index.document_index import DocumentContents as DocumentContents
+from .document_index.document_index import DocumentIndexClient as DocumentIndexClient
+from .document_index.document_index import DocumentIndexError as DocumentIndexError
+from .document_index.document_index import DocumentInfo as DocumentInfo
+from .document_index.document_index import DocumentPath as DocumentPath
+from .document_index.document_index import DocumentSearchResult as DocumentSearchResult
+from .document_index.document_index import (
+    ExternalServiceUnavailable as ExternalServiceUnavailable,
+)
+from .document_index.document_index import FilterField as FilterField
+from .document_index.document_index import FilterOps as FilterOps
+from .document_index.document_index import Filters as Filters
+from .document_index.document_index import IndexConfiguration as IndexConfiguration
+from .document_index.document_index import IndexPath as IndexPath
+from .document_index.document_index import InstructableEmbed as InstructableEmbed
+from .document_index.document_index import InternalError as InternalError
+from .document_index.document_index import InvalidInput as InvalidInput
+from .document_index.document_index import ResourceNotFound as ResourceNotFound
+from .document_index.document_index import SearchQuery as SearchQuery
+from .document_index.document_index import SemanticEmbed as SemanticEmbed
+from .retrievers.base_retriever import AsyncBaseRetriever as AsyncBaseRetriever
+from .retrievers.base_retriever import BaseRetriever as BaseRetriever
+from .retrievers.base_retriever import Document as Document
+from .retrievers.base_retriever import DocumentChunk as DocumentChunk
+from .retrievers.base_retriever import SearchResult as SearchResult
+from .retrievers.document_index_retriever import (
+    AsyncDocumentIndexRetriever as AsyncDocumentIndexRetriever,
+)
+from .retrievers.document_index_retriever import (
+    DocumentIndexRetriever as DocumentIndexRetriever,
+)
+from .retrievers.hybrid_qdrant_in_memory_retriever import (
+    HybridQdrantInMemoryRetriever as HybridQdrantInMemoryRetriever,
+)
+from .retrievers.qdrant_in_memory_retriever import (
+    QdrantInMemoryRetriever as QdrantInMemoryRetriever,
+)
+from .retrievers.qdrant_in_memory_retriever import RetrieverType as RetrieverType
+
+__all__ = [symbol for symbol in dir() if symbol and symbol[0].isupper()]

--- a/pharia_data_sdk/connectors/document_index/__init__.py
+++ b/pharia_data_sdk/connectors/document_index/__init__.py
@@ -1,0 +1,26 @@
+from .document_index import (
+    AsyncDocumentIndexClient as AsyncDocumentIndexClient,
+)
+from .document_index import CollectionPath as CollectionPath
+from .document_index import ConstraintViolation as ConstraintViolation
+from .document_index import DocumentIndexClient as DocumentIndexClient
+from .document_index import DocumentIndexError as DocumentIndexError
+from .document_index import DocumentInfo as DocumentInfo
+from .document_index import DocumentPath as DocumentPath
+from .document_index import DocumentSearchResult as DocumentSearchResult
+from .document_index import (
+    ExternalServiceUnavailable as ExternalServiceUnavailable,
+)
+from .document_index import FilterField as FilterField
+from .document_index import FilterOps as FilterOps
+from .document_index import Filters as Filters
+from .document_index import IndexConfiguration as IndexConfiguration
+from .document_index import IndexPath as IndexPath
+from .document_index import InstructableEmbed as InstructableEmbed
+from .document_index import InternalError as InternalError
+from .document_index import InvalidInput as InvalidInput
+from .document_index import ResourceNotFound as ResourceNotFound
+from .document_index import SearchQuery as SearchQuery
+from .document_index import SemanticEmbed as SemanticEmbed
+
+__all__ = [symbol for symbol in dir() if symbol and symbol[0].isupper()]

--- a/pharia_data_sdk/connectors/retrievers/__init__.py
+++ b/pharia_data_sdk/connectors/retrievers/__init__.py
@@ -1,0 +1,20 @@
+from .base_retriever import AsyncBaseRetriever as AsyncBaseRetriever
+from .base_retriever import BaseRetriever as BaseRetriever
+from .base_retriever import Document as Document
+from .base_retriever import DocumentChunk as DocumentChunk
+from .base_retriever import SearchResult as SearchResult
+from .document_index_retriever import (
+    AsyncDocumentIndexRetriever as AsyncDocumentIndexRetriever,
+)
+from .document_index_retriever import (
+    DocumentIndexRetriever as DocumentIndexRetriever,
+)
+from .hybrid_qdrant_in_memory_retriever import (
+    HybridQdrantInMemoryRetriever as HybridQdrantInMemoryRetriever,
+)
+from .qdrant_in_memory_retriever import (
+    QdrantInMemoryRetriever as QdrantInMemoryRetriever,
+)
+from .qdrant_in_memory_retriever import RetrieverType as RetrieverType
+
+__all__ = [symbol for symbol in dir() if symbol and symbol[0].isupper()]


### PR DESCRIPTION
- also expose the classes and models on `/connectors` or specific directory level for easier access