### PR TITLE
feat(document-index): allow base urls with path

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip install pharia-data-sdk
 ```python
 from pharia_data_sdk.connectors.data import DataClient
 
-client = DataClient(token="<token>", base_data_platform_url="<base_data_platform_url>")
+client = DataClient(token="<token>", base_url="<base_data_platform_url>")
 
 repositories = client.list_repositories()
 repository = repositories[0]
@@ -28,10 +28,11 @@ dataset = datasets[0]
 ```
 
 ### Document Index Connector
+
 ```python
 from pharia_data_sdk.connectors.document_index.document_index import DocumentIndexClient, SearchQuery
 
-client = DocumentIndexClient(token="<token>", base_document_index_url="<base_document_index_url>")
+client = DocumentIndexClient(token="<token>", base_url="<base_document_index_url>")
 
 namespaces = client.list_namespaces()
 collections = client.list_collections(namespaces[0])
@@ -40,12 +41,13 @@ client.search(collections[0], indexes[0].index, SearchQuery(query="What fish is 
 ```
 
 ### Retrievers
+
 ```python
 from pharia_data_sdk.connectors.retrievers.document_index_retriever import DocumentIndexRetriever
 from pharia_data_sdk.connectors.document_index.document_index import DocumentIndexClient
 
 retriever = DocumentIndexRetriever(
-    document_index=DocumentIndexClient(token="<token>", base_document_index_url="<base_document_index_url>"),
+    document_index=DocumentIndexClient(token="<token>", base_url="<base_document_index_url>"),
     index_name="<index_name>",
     namespace="<namespace>",
     collection="<collection>",

--- a/docs/source/01-quickstart.md
+++ b/docs/source/01-quickstart.md
@@ -13,7 +13,7 @@ pip install pharia-data-sdk
 ```python
 from pharia_data_sdk.connectors.data import DataClient
 
-client = DataClient(token="<token>", base_data_platform_url="<base_data_platform_url>")
+client = DataClient(token="<token>", base_url="<base_data_platform_url>")
 
 repositories = client.list_repositories()
 repository = repositories[0]
@@ -22,10 +22,11 @@ dataset = datasets[0]
 ```
 
 ### Document Index Connector
+
 ```python
 from pharia_data_sdk.connectors.document_index.document_index import DocumentIndexClient, SearchQuery
 
-client = DocumentIndexClient(token="<token>", base_document_index_url="<base_document_index_url>")
+client = DocumentIndexClient(token="<token>", base_url="<base_document_index_url>")
 
 namespaces = client.list_namespaces()
 collections = client.list_collections(namespaces[0])
@@ -34,12 +35,13 @@ client.search(collections[0], indexes[0].index, SearchQuery(query="What fish is 
 ```
 
 ### Retrievers
+
 ```python
 from pharia_data_sdk.connectors.retrievers.document_index_retriever import DocumentIndexRetriever
 from pharia_data_sdk.connectors.document_index.document_index import DocumentIndexClient
 
 retriever = DocumentIndexRetriever(
-    document_index=DocumentIndexClient(token="<token>", base_document_index_url="<base_document_index_url>"),
+    document_index=DocumentIndexClient(token="<token>", base_url="<base_document_index_url>"),
     index_name="<index_name>",
     namespace="<namespace>",
     collection="<collection>",

--- a/pharia_data_sdk/connectors/data/data.py
+++ b/pharia_data_sdk/connectors/data/data.py
@@ -48,17 +48,17 @@ class DataClient:
     def __init__(
         self,
         token: str | None,
-        base_data_platform_url: str = "http://localhost:8000",
+        base_url: str = "http://localhost:8000",
         session: requests.Session | None = None,
     ) -> None:
         """Initialize the Data Client.
 
         Args:
             token: Access token
-            base_data_platform_url: Base URL of the Studio Data API. Defaults to "http://localhost:8000".
+            base_url: Base URL of the Studio Data API. Defaults to "http://localhost:8000".
             session: a already created requests session. Defaults to None.
         """
-        self._base_data_platform_url = base_data_platform_url
+        self._base_url = base_url
         self.headers = {
             **({"Authorization": f"Bearer {token}"} if token is not None else {}),
         }
@@ -93,7 +93,7 @@ class DataClient:
         Returns:
             List of :class:`DataRepository` objects
         """
-        url = urljoin(self._base_data_platform_url, "api/v1/repositories")
+        url = urljoin(self._base_url, "api/v1/repositories")
         query = urlencode({"page": page, "size": size})
         response = self._do_request("GET", f"{url}?{query}")
         repositories = response.json()
@@ -110,7 +110,7 @@ class DataClient:
         Returns:
             :class:`DataRepository` new object
         """
-        url = urljoin(self._base_data_platform_url, "api/v1/repositories")
+        url = urljoin(self._base_url, "api/v1/repositories")
         response = self._do_request(
             "POST", url, json=repository.model_dump(by_alias=True)
         )
@@ -125,9 +125,7 @@ class DataClient:
         Returns:
             :class:`DataRepository` object
         """
-        url = urljoin(
-            self._base_data_platform_url, f"api/v1/repositories/{repository_id}"
-        )
+        url = urljoin(self._base_url, f"api/v1/repositories/{repository_id}")
         response = self._do_request("GET", url)
         return DataRepository(**response.json())
 
@@ -142,7 +140,7 @@ class DataClient:
             :class:`DataDataset` new object
         """
         url = urljoin(
-            self._base_data_platform_url,
+            self._base_url,
             f"api/v1/repositories/{repository_id}/datasets",
         )
         body = {
@@ -173,7 +171,7 @@ class DataClient:
             List of :class:`DataDataset` from a given repository
         """
         url = urljoin(
-            self._base_data_platform_url,
+            self._base_url,
             f"api/v1/repositories/{repository_id}/datasets",
         )
         query = urlencode({"page": page, "size": size})
@@ -192,7 +190,7 @@ class DataClient:
             :class:`DataDataset` object
         """
         url = urljoin(
-            self._base_data_platform_url,
+            self._base_url,
             f"api/v1/repositories/{repository_id}/datasets/{dataset_id}",
         )
         response = self._do_request("GET", url)
@@ -206,7 +204,7 @@ class DataClient:
             dataset_id: DataDataset ID
         """
         url = urljoin(
-            self._base_data_platform_url,
+            self._base_url,
             f"api/v1/repositories/{repository_id}/datasets/{dataset_id}",
         )
         self._do_request("DELETE", url)
@@ -222,7 +220,7 @@ class DataClient:
             :class Iterator of datapoints(Any)
         """
         url = urljoin(
-            self._base_data_platform_url,
+            self._base_url,
             f"api/v1/repositories/{repository_id}/datasets/{dataset_id}/datapoints",
         )
         response = self._do_request("GET", url, stream=True)
@@ -237,7 +235,7 @@ class DataClient:
         Returns:
             :class:`DataStage` new object
         """
-        url = urljoin(self._base_data_platform_url, "api/v1/stages")
+        url = urljoin(self._base_url, "api/v1/stages")
         response = self._do_request("POST", url, json=stage.model_dump(by_alias=True))
         return DataStage(**response.json())
 
@@ -251,7 +249,7 @@ class DataClient:
         Returns:
             List of :class:`DataStage` objects
         """
-        url = urljoin(self._base_data_platform_url, "api/v1/stages")
+        url = urljoin(self._base_url, "api/v1/stages")
         query = urlencode({"page": page, "size": size})
         response = self._do_request("GET", f"{url}?{query}")
         stages = response.json()
@@ -266,7 +264,7 @@ class DataClient:
         Returns:
             :class:`DataStage` object
         """
-        url = urljoin(self._base_data_platform_url, f"api/v1/stages/{stage_id}")
+        url = urljoin(self._base_url, f"api/v1/stages/{stage_id}")
         response = self._do_request("GET", url)
         return DataStage(**response.json())
 
@@ -281,7 +279,7 @@ class DataClient:
             :class:`DataFile` new object
         """
         url = urljoin(
-            self._base_data_platform_url,
+            self._base_url,
             f"api/v1/stages/{stage_id}/files",
         )
 
@@ -311,7 +309,7 @@ class DataClient:
             List of :class:`DataFile` objects
         """
         url = urljoin(
-            self._base_data_platform_url,
+            self._base_url,
             f"api/v1/stages/{stage_id}/files",
         )
         query = urlencode({"page": page, "size": size})
@@ -329,9 +327,7 @@ class DataClient:
         Returns:
             File bytes
         """
-        url = urljoin(
-            self._base_data_platform_url, f"api/v1/stages/{stage_id}/files/{file_id}"
-        )
+        url = urljoin(self._base_url, f"api/v1/stages/{stage_id}/files/{file_id}")
         response = self._do_request("GET", url)
         return io.BytesIO(response.content)
 

--- a/pharia_data_sdk/connectors/data/data.py
+++ b/pharia_data_sdk/connectors/data/data.py
@@ -48,14 +48,14 @@ class DataClient:
     def __init__(
         self,
         token: str | None,
-        base_url: str = "http://localhost:8000",
+        base_url: str,
         session: requests.Session | None = None,
     ) -> None:
         """Initialize the Data Client.
 
         Args:
             token: Access token
-            base_url: Base URL of the Studio Data API. Defaults to "http://localhost:8000".
+            base_url: Base URL of the Studio Data API.
             session: a already created requests session. Defaults to None.
         """
         self._base_url = base_url

--- a/pharia_data_sdk/connectors/document_index/document_index.py
+++ b/pharia_data_sdk/connectors/document_index/document_index.py
@@ -476,14 +476,14 @@ class DocumentIndexClient:
 
     def __init__(
         self,
-        token: str | None,
+        token: str,
         base_url: str,
     ) -> None:
         self._base_url = f"{base_url.rstrip('/')}/"
         self.headers = {
             "Content-Type": "application/json",
             "Accept": "application/json",
-            **({"Authorization": f"Bearer {token}"} if token is not None else {}),
+            "Authorization": f"Bearer {token}",
         }
 
     def __url(self, relative_path: str) -> str:
@@ -990,7 +990,7 @@ class AsyncDocumentIndexClient:
 
     def __init__(
         self,
-        token: str | None,
+        token: str,
         base_url: str,
     ) -> None:
         """Initializes an async client for the document index.
@@ -1003,7 +1003,7 @@ class AsyncDocumentIndexClient:
         self.headers = {
             "Content-Type": "application/json",
             "Accept": "application/json",
-            **({"Authorization": f"Bearer {token}"} if token is not None else {}),
+            "Authorization": f"Bearer {token}",
         }
         self._session: Optional[ClientSession] = None
 

--- a/pharia_data_sdk/connectors/document_index/document_index.py
+++ b/pharia_data_sdk/connectors/document_index/document_index.py
@@ -471,20 +471,23 @@ class DocumentIndexClient:
 
     Args:
         token: A valid token for the document index API.
-        base_document_index_url: The url of the document index' API.
+        base_url: The url of the document index API.
     """
 
     def __init__(
         self,
         token: str | None,
-        base_document_index_url: str = "https://document-index.aleph-alpha.com",
+        base_url: str = "https://document-index.aleph-alpha.com",
     ) -> None:
-        self._base_document_index_url = base_document_index_url
+        self._base_url = f"{base_url.rstrip('/')}/"
         self.headers = {
             "Content-Type": "application/json",
             "Accept": "application/json",
             **({"Authorization": f"Bearer {token}"} if token is not None else {}),
         }
+
+    def __url(self, relative_path: str) -> str:
+        return urljoin(self._base_url, relative_path)
 
     def list_namespaces(self) -> Sequence[str]:
         """Lists all available namespaces.
@@ -492,7 +495,7 @@ class DocumentIndexClient:
         Returns:
             List of all available namespaces.
         """
-        url = urljoin(self._base_document_index_url, "namespaces")
+        url = self.__url("namespaces")
         response = requests.get(url, headers=self.headers)
         self._raise_for_status(response)
         return [str(namespace) for namespace in response.json()]
@@ -506,10 +509,9 @@ class DocumentIndexClient:
         Args:
             collection_path: Path to the collection of interest.
         """
-        url_suffix = (
-            f"/collections/{collection_path.namespace}/{collection_path.collection}"
+        url = self.__url(
+            f"collections/{collection_path.namespace}/{collection_path.collection}"
         )
-        url = urljoin(self._base_document_index_url, url_suffix)
         response = requests.put(url, headers=self.headers)
         self._raise_for_status(response)
 
@@ -519,10 +521,9 @@ class DocumentIndexClient:
         Args:
             collection_path: Path to the collection of interest.
         """
-        url_suffix = (
+        url = self.__url(
             f"collections/{collection_path.namespace}/{collection_path.collection}"
         )
-        url = urljoin(self._base_document_index_url, url_suffix)
         response = requests.delete(url, headers=self.headers)
         self._raise_for_status(response)
 
@@ -536,8 +537,7 @@ class DocumentIndexClient:
         Returns:
             List of all `CollectionPath` instances in the given namespace.
         """
-        url_suffix = f"collections/{namespace}"
-        url = urljoin(self._base_document_index_url, url_suffix)
+        url = self.__url(f"collections/{namespace}")
         response = requests.get(url, headers=self.headers)
         self._raise_for_status(response)
         return [
@@ -555,8 +555,7 @@ class DocumentIndexClient:
         Returns:
             List of all `IndexPath` instances in the given namespace.
         """
-        url_suffix = f"indexes/{namespace}"
-        url = urljoin(self._base_document_index_url, url_suffix)
+        url = self.__url(f"indexes/{namespace}")
         response = requests.get(url, headers=self.headers)
         self._raise_for_status(response)
         return [
@@ -572,9 +571,7 @@ class DocumentIndexClient:
             index_path: Path to the index.
             index_configuration: Configuration of the index to be created.
         """
-        url_suffix = f"indexes/{index_path.namespace}/{index_path.index}"
-        url = urljoin(self._base_document_index_url, url_suffix)
-
+        url = self.__url(f"indexes/{index_path.namespace}/{index_path.index}")
         data = {
             "chunk_size": index_configuration.chunk_size,
             "chunk_overlap": index_configuration.chunk_overlap,
@@ -590,9 +587,7 @@ class DocumentIndexClient:
         Args:
             index_path: Path to the index.
         """
-        url_suffix = f"indexes/{index_path.namespace}/{index_path.index}"
-        url = urljoin(self._base_document_index_url, url_suffix)
-
+        url = self.__url(f"indexes/{index_path.namespace}/{index_path.index}")
         response = requests.delete(url, headers=self.headers)
         self._raise_for_status(response)
 
@@ -618,7 +613,7 @@ class DocumentIndexClient:
         if len(filter_index_name) > 50:
             raise ValueError("Filter index name cannot be longer than 50 characters.")
 
-        url = f"{self._base_document_index_url}/filter_indexes/{namespace}/{filter_index_name}"
+        url = self.__url(f"filter_indexes/{namespace}/{filter_index_name}")
         data = {"field_name": field_name, "field_type": field_type}
         response = requests.put(url, data=dumps(data), headers=self.headers)
         self._raise_for_status(response)
@@ -632,9 +627,7 @@ class DocumentIndexClient:
         Returns:
             Configuration of the index.
         """
-        url_suffix = f"indexes/{index_path.namespace}/{index_path.index}"
-        url = urljoin(self._base_document_index_url, url_suffix)
-
+        url = self.__url(f"indexes/{index_path.namespace}/{index_path.index}")
         response = requests.get(url, headers=self.headers)
         self._raise_for_status(response)
         response_json: Mapping[str, Any] = response.json()
@@ -654,9 +647,9 @@ class DocumentIndexClient:
             collection_path: Path to the collection of interest.
             index_name: Name of the index.
         """
-        url_suffix = f"collections/{collection_path.namespace}/{collection_path.collection}/indexes/{index_name}"
-        url = urljoin(self._base_document_index_url, url_suffix)
-
+        url = self.__url(
+            f"collections/{collection_path.namespace}/{collection_path.collection}/indexes/{index_name}"
+        )
         response = requests.put(url, headers=self.headers)
         self._raise_for_status(response)
 
@@ -670,7 +663,9 @@ class DocumentIndexClient:
             index_name: Name of the index to assign the filter index to.
             filter_index_name: Name of the filter index.
         """
-        url = f"{self._base_document_index_url}/collections/{collection_path.namespace}/{collection_path.collection}/indexes/{index_name}/filter_indexes/{filter_index_name}"
+        url = self.__url(
+            f"collections/{collection_path.namespace}/{collection_path.collection}/indexes/{index_name}/filter_indexes/{filter_index_name}"
+        )
         response = requests.put(url, headers=self.headers)
         self._raise_for_status(response)
 
@@ -684,7 +679,9 @@ class DocumentIndexClient:
             index_name: Name of the index to unassign the filter index from.
             filter_index_name: Name of the filter index.
         """
-        url = f"{self._base_document_index_url}/collections/{collection_path.namespace}/{collection_path.collection}/indexes/{index_name}/filter_indexes/{filter_index_name}"
+        url = self.__url(
+            f"collections/{collection_path.namespace}/{collection_path.collection}/indexes/{index_name}/filter_indexes/{filter_index_name}"
+        )
         response = requests.delete(url, headers=self.headers)
         self._raise_for_status(response)
 
@@ -697,9 +694,9 @@ class DocumentIndexClient:
             collection_path: Path to the collection of interest.
             index_name: Name of the index.
         """
-        url_suffix = f"collections/{collection_path.namespace}/{collection_path.collection}/indexes/{index_name}"
-        url = urljoin(self._base_document_index_url, url_suffix)
-
+        url = self.__url(
+            f"collections/{collection_path.namespace}/{collection_path.collection}/indexes/{index_name}"
+        )
         response = requests.delete(url, headers=self.headers)
         self._raise_for_status(response)
 
@@ -712,7 +709,7 @@ class DocumentIndexClient:
             namespace: The namespace to delete the filter index from.
             filter_index_name: The name of the filter index to delete.
         """
-        url = f"{self._base_document_index_url}/filter_indexes/{namespace}/{filter_index_name}"
+        url = self.__url(f"filter_indexes/{namespace}/{filter_index_name}")
         response = requests.delete(url, headers=self.headers)
         self._raise_for_status(response)
 
@@ -725,7 +722,9 @@ class DocumentIndexClient:
         Returns:
             The number of unembedded documents in a collection.
         """
-        url = f"{self._base_document_index_url}/collections/{collection_path.namespace}/{collection_path.collection}/progress"
+        url = self.__url(
+            f"collections/{collection_path.namespace}/{collection_path.collection}/progress"
+        )
         response = requests.get(url, headers=self.headers)
         self._raise_for_status(response)
         return int(response.text)
@@ -741,9 +740,9 @@ class DocumentIndexClient:
         Returns:
             List of all indexes that are assigned to the collection.
         """
-        url_suffix = f"collections/{collection_path.namespace}/{collection_path.collection}/indexes"
-        url = urljoin(self._base_document_index_url, url_suffix)
-
+        url = self.__url(
+            f"collections/{collection_path.namespace}/{collection_path.collection}/indexes"
+        )
         response = requests.get(url, headers=self.headers)
         self._raise_for_status(response)
         return [str(index_name) for index_name in response.json()]
@@ -760,7 +759,9 @@ class DocumentIndexClient:
         Returns:
             List of all filter-indexes that are assigned to the collection.
         """
-        url = f"{self._base_document_index_url}/collections/{collection_path.namespace}/{collection_path.collection}/indexes/{index_name}/filter_indexes"
+        url = self.__url(
+            f"collections/{collection_path.namespace}/{collection_path.collection}/indexes/{index_name}/filter_indexes"
+        )
         response = requests.get(url, headers=self.headers)
         self._raise_for_status(response)
         return [str(filter_index_name) for filter_index_name in response.json()]
@@ -774,7 +775,7 @@ class DocumentIndexClient:
         Returns:
             List of all filter indexes in the namespace.
         """
-        url = f"{self._base_document_index_url}/filter_indexes/{namespace}"
+        url = self.__url(f"filter_indexes/{namespace}")
         response = requests.get(url, headers=self.headers)
         self._raise_for_status(response)
         return [str(filter_index_name) for filter_index_name in response.json()]
@@ -794,9 +795,9 @@ class DocumentIndexClient:
             contents: Actual content of the document.
                 Currently only supports text.
         """
-        url_suffix = f"collections/{document_path.collection_path.namespace}/{document_path.collection_path.collection}/docs/{document_path.encoded_document_name()}"
-        url = urljoin(self._base_document_index_url, url_suffix)
-
+        url = self.__url(
+            f"collections/{document_path.collection_path.namespace}/{document_path.collection_path.collection}/docs/{document_path.encoded_document_name()}"
+        )
         response = requests.put(
             url, data=dumps(contents._to_modalities_json()), headers=self.headers
         )
@@ -808,9 +809,9 @@ class DocumentIndexClient:
         Args:
             document_path: Consists of `collection_path` and name of document to be deleted.
         """
-        url_suffix = f"/collections/{document_path.collection_path.namespace}/{document_path.collection_path.collection}/docs/{document_path.encoded_document_name()}"
-        url = urljoin(self._base_document_index_url, url_suffix)
-
+        url = self.__url(
+            f"collections/{document_path.collection_path.namespace}/{document_path.collection_path.collection}/docs/{document_path.encoded_document_name()}"
+        )
         response = requests.delete(url, headers=self.headers)
         self._raise_for_status(response)
 
@@ -823,9 +824,9 @@ class DocumentIndexClient:
         Returns:
             Content of the retrieved document.
         """
-        url_suffix = f"collections/{document_path.collection_path.namespace}/{document_path.collection_path.collection}/docs/{document_path.encoded_document_name()}"
-        url = urljoin(self._base_document_index_url, url_suffix)
-
+        url = self.__url(
+            f"collections/{document_path.collection_path.namespace}/{document_path.collection_path.collection}/docs/{document_path.encoded_document_name()}"
+        )
         response = requests.get(url, headers=self.headers)
         self._raise_for_status(response)
         return DocumentContents._from_modalities_json(response.json())
@@ -852,11 +853,9 @@ class DocumentIndexClient:
                 max_documents=None, starts_with=None
             )
 
-        url_suffix = (
+        url = self.__url(
             f"collections/{collection_path.namespace}/{collection_path.collection}/docs"
         )
-        url = urljoin(self._base_document_index_url, url_suffix)
-
         query_params = {}
         if filter_query_params.max_documents:
             query_params["max_documents"] = str(filter_query_params.max_documents)
@@ -883,9 +882,9 @@ class DocumentIndexClient:
         Returns:
             Result of the search operation. Will be empty if nothing was retrieved.
         """
-        url_suffix = f"collections/{collection_path.namespace}/{collection_path.collection}/indexes/{index_name}/search"
-        url = urljoin(self._base_document_index_url, url_suffix)
-
+        url = self.__url(
+            f"collections/{collection_path.namespace}/{collection_path.collection}/indexes/{index_name}/search"
+        )
         filters: list[dict[str, Any]] = [{"with": [{"modality": "text"}]}]
         if search_query.filters:
             for metadata_filter in search_query.filters:
@@ -928,9 +927,9 @@ class DocumentIndexClient:
         Returns:
             List of all chunks of the indexed document.
         """
-        url_suffix = f"collections/{document_path.collection_path.namespace}/{document_path.collection_path.collection}/docs/{document_path.encoded_document_name()}/indexes/{index_name}/chunks"
-        url = urljoin(self._base_document_index_url, url_suffix)
-
+        url = self.__url(
+            f"collections/{document_path.collection_path.namespace}/{document_path.collection_path.collection}/docs/{document_path.encoded_document_name()}/indexes/{index_name}/chunks"
+        )
         response = requests.get(url, headers=self.headers)
         self._raise_for_status(response)
         return [
@@ -969,7 +968,7 @@ class AsyncDocumentIndexClient:
         ... )
 
         >>> async def main():
-        ...     async with AsyncDocumentIndexClient(os.getenv("AA_TOKEN")) as document_index:
+        ...     async with AsyncDocumentIndexClient(os.getenv("AA_TOKEN"), os.getenv("AA_TOKEN")) as document_index:
         ...         collection_path = CollectionPath(
         ...             namespace="my-namespace", collection="previously-created-collection"
         ...         )
@@ -992,21 +991,26 @@ class AsyncDocumentIndexClient:
     def __init__(
         self,
         token: str | None,
-        base_document_index_url: str = "https://document-index.aleph-alpha.com",
+        base_url: str = "https://document-index.aleph-alpha.com",
     ) -> None:
         """Initializes an async client for the document index.
 
         Args:
             token: A valid token for the document index API.
-            base_document_index_url: The URL of the Document Index API. Defaults to "https://document-index.aleph-alpha.com".
+            base_url: The URL of the Document Index API.
         """
-        self._base_document_index_url = base_document_index_url
+        self._base_url = f"{base_url.rstrip('/')}/"
         self.headers = {
             "Content-Type": "application/json",
             "Accept": "application/json",
             **({"Authorization": f"Bearer {token}"} if token is not None else {}),
         }
         self._session: Optional[ClientSession] = None
+
+    def __url(self, relative_path: str) -> str:
+        url = urljoin(self._base_url, relative_path)
+        print(f"Generated URL: {url}")
+        return url
 
     @property
     def active_session(self) -> ClientSession:
@@ -1029,7 +1033,7 @@ class AsyncDocumentIndexClient:
         Returns:
             List of all available namespaces.
         """
-        url = urljoin(self._base_document_index_url, "namespaces")
+        url = self.__url("namespaces")
         async with self.active_session.get(url, headers=self.headers) as response:
             await self._raise_for_status(response)
             data = await response.json()
@@ -1044,10 +1048,9 @@ class AsyncDocumentIndexClient:
         Args:
             collection_path: Path to the collection of interest.
         """
-        url_suffix = (
-            f"/collections/{collection_path.namespace}/{collection_path.collection}"
+        url = self.__url(
+            f"collections/{collection_path.namespace}/{collection_path.collection}"
         )
-        url = urljoin(self._base_document_index_url, url_suffix)
         async with self.active_session.put(url, headers=self.headers) as response:
             await self._raise_for_status(response)
 
@@ -1057,10 +1060,9 @@ class AsyncDocumentIndexClient:
         Args:
             collection_path: Path to the collection of interest.
         """
-        url_suffix = (
+        url = self.__url(
             f"collections/{collection_path.namespace}/{collection_path.collection}"
         )
-        url = urljoin(self._base_document_index_url, url_suffix)
         async with self.active_session.delete(url, headers=self.headers) as response:
             await self._raise_for_status(response)
 
@@ -1074,8 +1076,7 @@ class AsyncDocumentIndexClient:
         Returns:
             List of all `CollectionPath` instances in the given namespace.
         """
-        url_suffix = f"collections/{namespace}"
-        url = urljoin(self._base_document_index_url, url_suffix)
+        url = self.__url(f"collections/{namespace}")
         async with self.active_session.get(url, headers=self.headers) as response:
             await self._raise_for_status(response)
             data = await response.json()
@@ -1094,8 +1095,7 @@ class AsyncDocumentIndexClient:
         Returns:
             List of all `IndexPath` instances in the given namespace.
         """
-        url_suffix = f"indexes/{namespace}"
-        url = urljoin(self._base_document_index_url, url_suffix)
+        url = self.__url(f"indexes/{namespace}")
         async with self.active_session.get(url, headers=self.headers) as response:
             await self._raise_for_status(response)
             data = await response.json()
@@ -1110,9 +1110,7 @@ class AsyncDocumentIndexClient:
             index_path: Path to the index.
             index_configuration: Configuration of the index to be created.
         """
-        url_suffix = f"indexes/{index_path.namespace}/{index_path.index}"
-        url = urljoin(self._base_document_index_url, url_suffix)
-
+        url = self.__url(f"indexes/{index_path.namespace}/{index_path.index}")
         data = {
             "chunk_size": index_configuration.chunk_size,
             "chunk_overlap": index_configuration.chunk_overlap,
@@ -1131,8 +1129,7 @@ class AsyncDocumentIndexClient:
         Args:
             index_path: Path to the index.
         """
-        url_suffix = f"indexes/{index_path.namespace}/{index_path.index}"
-        url = urljoin(self._base_document_index_url, url_suffix)
+        url = self.__url(f"indexes/{index_path.namespace}/{index_path.index}")
         async with self.active_session.delete(url, headers=self.headers) as response:
             await self._raise_for_status(response)
 
@@ -1161,7 +1158,7 @@ class AsyncDocumentIndexClient:
         if len(filter_index_name) > 50:
             raise ValueError("Filter index name cannot be longer than 50 characters.")
 
-        url = f"{self._base_document_index_url}/filter_indexes/{namespace}/{filter_index_name}"
+        url = self.__url(f"filter_indexes/{namespace}/{filter_index_name}")
         data = {"field_name": field_name, "field_type": field_type}
         async with self.active_session.put(
             url, data=dumps(data), headers=self.headers
@@ -1177,8 +1174,7 @@ class AsyncDocumentIndexClient:
         Returns:
             Configuration of the index.
         """
-        url_suffix = f"indexes/{index_path.namespace}/{index_path.index}"
-        url = urljoin(self._base_document_index_url, url_suffix)
+        url = self.__url(f"indexes/{index_path.namespace}/{index_path.index}")
         async with self.active_session.get(url, headers=self.headers) as response:
             await self._raise_for_status(response)
             response_json: Mapping[str, Any] = await response.json()
@@ -1198,8 +1194,9 @@ class AsyncDocumentIndexClient:
             collection_path: Path to the collection of interest.
             index_name: Name of the index.
         """
-        url_suffix = f"collections/{collection_path.namespace}/{collection_path.collection}/indexes/{index_name}"
-        url = urljoin(self._base_document_index_url, url_suffix)
+        url = self.__url(
+            f"collections/{collection_path.namespace}/{collection_path.collection}/indexes/{index_name}"
+        )
         async with self.active_session.put(url, headers=self.headers) as response:
             await self._raise_for_status(response)
 
@@ -1213,7 +1210,9 @@ class AsyncDocumentIndexClient:
             index_name: Name of the index to assign the filter index to.
             filter_index_name: Name of the filter index.
         """
-        url = f"{self._base_document_index_url}/collections/{collection_path.namespace}/{collection_path.collection}/indexes/{index_name}/filter_indexes/{filter_index_name}"
+        url = self.__url(
+            f"collections/{collection_path.namespace}/{collection_path.collection}/indexes/{index_name}/filter_indexes/{filter_index_name}"
+        )
         async with self.active_session.put(url, headers=self.headers) as response:
             await self._raise_for_status(response)
 
@@ -1227,7 +1226,9 @@ class AsyncDocumentIndexClient:
             index_name: Name of the index to unassign the filter index from.
             filter_index_name: Name of the filter index.
         """
-        url = f"{self._base_document_index_url}/collections/{collection_path.namespace}/{collection_path.collection}/indexes/{index_name}/filter_indexes/{filter_index_name}"
+        url = self.__url(
+            f"collections/{collection_path.namespace}/{collection_path.collection}/indexes/{index_name}/filter_indexes/{filter_index_name}"
+        )
         async with self.active_session.delete(url, headers=self.headers) as response:
             await self._raise_for_status(response)
 
@@ -1240,8 +1241,9 @@ class AsyncDocumentIndexClient:
             collection_path: Path to the collection of interest.
             index_name: Name of the index.
         """
-        url_suffix = f"collections/{collection_path.namespace}/{collection_path.collection}/indexes/{index_name}"
-        url = urljoin(self._base_document_index_url, url_suffix)
+        url = self.__url(
+            f"collections/{collection_path.namespace}/{collection_path.collection}/indexes/{index_name}"
+        )
         async with self.active_session.delete(url, headers=self.headers) as response:
             await self._raise_for_status(response)
 
@@ -1254,7 +1256,7 @@ class AsyncDocumentIndexClient:
             namespace: The namespace to delete the filter index from.
             filter_index_name: The name of the filter index to delete.
         """
-        url = f"{self._base_document_index_url}/filter_indexes/{namespace}/{filter_index_name}"
+        url = self.__url(f"filter_indexes/{namespace}/{filter_index_name}")
         async with self.active_session.delete(url, headers=self.headers) as response:
             await self._raise_for_status(response)
 
@@ -1267,7 +1269,9 @@ class AsyncDocumentIndexClient:
         Returns:
             The number of unembedded documents in a collection.
         """
-        url = f"{self._base_document_index_url}/collections/{collection_path.namespace}/{collection_path.collection}/progress"
+        url = self.__url(
+            f"collections/{collection_path.namespace}/{collection_path.collection}/progress"
+        )
         async with self.active_session.get(url, headers=self.headers) as response:
             await self._raise_for_status(response)
             data = await response.text()
@@ -1284,8 +1288,9 @@ class AsyncDocumentIndexClient:
         Returns:
             List of all indexes that are assigned to the collection.
         """
-        url_suffix = f"collections/{collection_path.namespace}/{collection_path.collection}/indexes"
-        url = urljoin(self._base_document_index_url, url_suffix)
+        url = self.__url(
+            f"collections/{collection_path.namespace}/{collection_path.collection}/indexes"
+        )
         async with self.active_session.get(url, headers=self.headers) as response:
             await self._raise_for_status(response)
             data = await response.json()
@@ -1303,7 +1308,9 @@ class AsyncDocumentIndexClient:
         Returns:
             List of all filter-indexes that are assigned to the collection.
         """
-        url = f"{self._base_document_index_url}/collections/{collection_path.namespace}/{collection_path.collection}/indexes/{index_name}/filter_indexes"
+        url = self.__url(
+            f"collections/{collection_path.namespace}/{collection_path.collection}/indexes/{index_name}/filter_indexes"
+        )
         async with self.active_session.get(url, headers=self.headers) as response:
             await self._raise_for_status(response)
             data = await response.json()
@@ -1318,7 +1325,7 @@ class AsyncDocumentIndexClient:
         Returns:
             List of all filter indexes in the namespace.
         """
-        url = f"{self._base_document_index_url}/filter_indexes/{namespace}"
+        url = self.__url(f"filter_indexes/{namespace}")
         async with self.active_session.get(url, headers=self.headers) as response:
             await self._raise_for_status(response)
             data = await response.json()
@@ -1339,8 +1346,9 @@ class AsyncDocumentIndexClient:
             contents: Actual content of the document.
                 Currently only supports text.
         """
-        url_suffix = f"collections/{document_path.collection_path.namespace}/{document_path.collection_path.collection}/docs/{document_path.encoded_document_name()}"
-        url = urljoin(self._base_document_index_url, url_suffix)
+        url = self.__url(
+            f"collections/{document_path.collection_path.namespace}/{document_path.collection_path.collection}/docs/{document_path.encoded_document_name()}"
+        )
         async with self.active_session.put(
             url, data=dumps(contents._to_modalities_json()), headers=self.headers
         ) as response:
@@ -1352,8 +1360,9 @@ class AsyncDocumentIndexClient:
         Args:
             document_path: Consists of `collection_path` and name of document to be deleted.
         """
-        url_suffix = f"/collections/{document_path.collection_path.namespace}/{document_path.collection_path.collection}/docs/{document_path.encoded_document_name()}"
-        url = urljoin(self._base_document_index_url, url_suffix)
+        url = self.__url(
+            f"collections/{document_path.collection_path.namespace}/{document_path.collection_path.collection}/docs/{document_path.encoded_document_name()}"
+        )
         async with self.active_session.delete(url, headers=self.headers) as response:
             await self._raise_for_status(response)
 
@@ -1366,9 +1375,9 @@ class AsyncDocumentIndexClient:
         Returns:
             Content of the retrieved document.
         """
-        url_suffix = f"collections/{document_path.collection_path.namespace}/{document_path.collection_path.collection}/docs/{document_path.encoded_document_name()}"
-        url = urljoin(self._base_document_index_url, url_suffix)
-
+        url = self.__url(
+            f"collections/{document_path.collection_path.namespace}/{document_path.collection_path.collection}/docs/{document_path.encoded_document_name()}"
+        )
         async with self.active_session.get(url, headers=self.headers) as response:
             await self._raise_for_status(response)
             data = await response.json()
@@ -1396,11 +1405,9 @@ class AsyncDocumentIndexClient:
                 max_documents=None, starts_with=None
             )
 
-        url_suffix = (
+        url = self.__url(
             f"collections/{collection_path.namespace}/{collection_path.collection}/docs"
         )
-        url = urljoin(self._base_document_index_url, url_suffix)
-
         query_params = {}
         if filter_query_params.max_documents:
             query_params["max_documents"] = str(filter_query_params.max_documents)
@@ -1430,9 +1437,9 @@ class AsyncDocumentIndexClient:
         Returns:
             Result of the search operation. Will be empty if nothing was retrieved.
         """
-        url_suffix = f"collections/{collection_path.namespace}/{collection_path.collection}/indexes/{index_name}/search"
-        url = urljoin(self._base_document_index_url, url_suffix)
-
+        url = self.__url(
+            f"collections/{collection_path.namespace}/{collection_path.collection}/indexes/{index_name}/search"
+        )
         filters: list[dict[str, Any]] = [{"with": [{"modality": "text"}]}]
         if search_query.filters:
             for metadata_filter in search_query.filters:
@@ -1478,9 +1485,9 @@ class AsyncDocumentIndexClient:
         Returns:
             List of all chunks of the indexed document.
         """
-        url_suffix = f"collections/{document_path.collection_path.namespace}/{document_path.collection_path.collection}/docs/{document_path.encoded_document_name()}/indexes/{index_name}/chunks"
-        url = urljoin(self._base_document_index_url, url_suffix)
-
+        url = self.__url(
+            f"collections/{document_path.collection_path.namespace}/{document_path.collection_path.collection}/docs/{document_path.encoded_document_name()}/indexes/{index_name}/chunks"
+        )
         async with self.active_session.get(url, headers=self.headers) as response:
             await self._raise_for_status(response)
             data = await response.json()

--- a/pharia_data_sdk/connectors/document_index/document_index.py
+++ b/pharia_data_sdk/connectors/document_index/document_index.py
@@ -477,7 +477,7 @@ class DocumentIndexClient:
     def __init__(
         self,
         token: str | None,
-        base_url: str = "https://document-index.aleph-alpha.com",
+        base_url: str,
     ) -> None:
         self._base_url = f"{base_url.rstrip('/')}/"
         self.headers = {
@@ -991,7 +991,7 @@ class AsyncDocumentIndexClient:
     def __init__(
         self,
         token: str | None,
-        base_url: str = "https://document-index.aleph-alpha.com",
+        base_url: str,
     ) -> None:
         """Initializes an async client for the document index.
 

--- a/tests/conftest_document_index.py
+++ b/tests/conftest_document_index.py
@@ -45,15 +45,25 @@ R = TypeVar("R")
 
 
 @fixture(scope="session")
-def document_index(token: str) -> DocumentIndexClient:
-    return DocumentIndexClient(token, base_url=os.environ["DOCUMENT_INDEX_URL"])
+def base_url() -> str:
+    try:
+        return os.environ["DOCUMENT_INDEX_URL"]
+    except KeyError:
+        raise Exception(
+            "Environment variable 'DOCUMENT_INDEX_URL' is not set."
+        ) from None
+
+
+@fixture(scope="session")
+def document_index(token: str, base_url: str) -> DocumentIndexClient:
+    return DocumentIndexClient(token, base_url)
 
 
 @pytest_asyncio.fixture()
-async def async_document_index(token: str) -> AsyncIterator[AsyncDocumentIndexClient]:
-    async with AsyncDocumentIndexClient(
-        token, base_url=os.environ["DOCUMENT_INDEX_URL"]
-    ) as client:
+async def async_document_index(
+    token: str, base_url: str
+) -> AsyncIterator[AsyncDocumentIndexClient]:
+    async with AsyncDocumentIndexClient(token, base_url) as client:
         yield client
 
 

--- a/tests/conftest_document_index.py
+++ b/tests/conftest_document_index.py
@@ -46,15 +46,13 @@ R = TypeVar("R")
 
 @fixture(scope="session")
 def document_index(token: str) -> DocumentIndexClient:
-    return DocumentIndexClient(
-        token, base_document_index_url=os.environ["DOCUMENT_INDEX_URL"]
-    )
+    return DocumentIndexClient(token, base_url=os.environ["DOCUMENT_INDEX_URL"])
 
 
 @pytest_asyncio.fixture()
 async def async_document_index(token: str) -> AsyncIterator[AsyncDocumentIndexClient]:
     async with AsyncDocumentIndexClient(
-        token, base_document_index_url=os.environ["DOCUMENT_INDEX_URL"]
+        token, base_url=os.environ["DOCUMENT_INDEX_URL"]
     ) as client:
         yield client
 

--- a/tests/connectors/document_index/test_async_document_index.py
+++ b/tests/connectors/document_index/test_async_document_index.py
@@ -29,9 +29,11 @@ pytestmark = pytest.mark.document_index
 
 
 @pytest.mark.internal
-def test_document_index_sets_authorization_header_for_given_token() -> None:
+def test_document_index_sets_authorization_header_for_given_token(
+    base_url: str,
+) -> None:
     token = "some-token"
-    async_document_index = AsyncDocumentIndexClient(token)
+    async_document_index = AsyncDocumentIndexClient(token, base_url)
     assert async_document_index.headers["Authorization"] == f"Bearer {token}"
 
 

--- a/tests/connectors/document_index/test_async_document_index.py
+++ b/tests/connectors/document_index/test_async_document_index.py
@@ -36,12 +36,6 @@ def test_document_index_sets_authorization_header_for_given_token() -> None:
 
 
 @pytest.mark.internal
-def test_document_index_sets_no_authorization_header_when_token_is_none() -> None:
-    async_document_index = AsyncDocumentIndexClient(None)
-    assert "Authorization" not in async_document_index.headers
-
-
-@pytest.mark.internal
 async def test_document_index_lists_namespaces_async(
     async_document_index: AsyncDocumentIndexClient,
     async_document_index_namespace: str,

--- a/tests/connectors/document_index/test_document_index.py
+++ b/tests/connectors/document_index/test_document_index.py
@@ -31,11 +31,11 @@ pytestmark = pytest.mark.document_index
 
 
 @pytest.mark.internal
-def test_document_index_sets_authorization_header_for_given_token() -> None:
+def test_document_index_sets_authorization_header_for_given_token(
+    base_url: str,
+) -> None:
     token = "some-token"
-
-    document_index = DocumentIndexClient(token)
-
+    document_index = DocumentIndexClient(token, base_url)
     assert document_index.headers["Authorization"] == f"Bearer {token}"
 
 

--- a/tests/connectors/document_index/test_document_index.py
+++ b/tests/connectors/document_index/test_document_index.py
@@ -40,13 +40,6 @@ def test_document_index_sets_authorization_header_for_given_token() -> None:
 
 
 @pytest.mark.internal
-def test_document_index_sets_no_authorization_header_when_token_is_none() -> None:
-    document_index = DocumentIndexClient(None)
-
-    assert "Authorization" not in document_index.headers
-
-
-@pytest.mark.internal
 def test_document_index_lists_namespaces(
     document_index: DocumentIndexClient,
     document_index_namespace: str,


### PR DESCRIPTION
This changeset addresses multiple issues with setting base URLs for the document index clients.

## Base URL with paths
Due to the way URL paths for API endpoints have been joined to the base URL, some endpoints wouldn't work if the base URL contained a path itself.

## Default value for `base_url`
Setting a default base URL doesn't make sense for most of the target audience of this SDK.

## Required API Tokens
The document index isn't functional without providing an API token, so the `token` parameter shouldn't be optional.