### PR TITLE
feat: allow base urls with path

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip install pharia-data-sdk
 ```python
 from pharia_data_sdk.connectors.data import DataClient
 
-client = DataClient(token="<token>", base_data_platform_url="<base_data_platform_url>")
+client = DataClient(token="<token>", base_url="<base_data_platform_url>")
 
 repositories = client.list_repositories()
 repository = repositories[0]
@@ -28,10 +28,11 @@ dataset = datasets[0]
 ```
 
 ### Document Index Connector
+
 ```python
 from pharia_data_sdk.connectors.document_index.document_index import DocumentIndexClient, SearchQuery
 
-client = DocumentIndexClient(token="<token>", base_document_index_url="<base_document_index_url>")
+client = DocumentIndexClient(token="<token>", base_url="<base_document_index_url>")
 
 namespaces = client.list_namespaces()
 collections = client.list_collections(namespaces[0])
@@ -40,12 +41,13 @@ client.search(collections[0], indexes[0].index, SearchQuery(query="What fish is 
 ```
 
 ### Retrievers
+
 ```python
 from pharia_data_sdk.connectors.retrievers.document_index_retriever import DocumentIndexRetriever
 from pharia_data_sdk.connectors.document_index.document_index import DocumentIndexClient
 
 retriever = DocumentIndexRetriever(
-    document_index=DocumentIndexClient(token="<token>", base_document_index_url="<base_document_index_url>"),
+    document_index=DocumentIndexClient(token="<token>", base_url="<base_document_index_url>"),
     index_name="<index_name>",
     namespace="<namespace>",
     collection="<collection>",

--- a/docs/source/01-quickstart.md
+++ b/docs/source/01-quickstart.md
@@ -13,7 +13,7 @@ pip install pharia-data-sdk
 ```python
 from pharia_data_sdk.connectors.data import DataClient
 
-client = DataClient(token="<token>", base_data_platform_url="<base_data_platform_url>")
+client = DataClient(token="<token>", base_url="<base_data_platform_url>")
 
 repositories = client.list_repositories()
 repository = repositories[0]
@@ -22,10 +22,11 @@ dataset = datasets[0]
 ```
 
 ### Document Index Connector
+
 ```python
 from pharia_data_sdk.connectors.document_index.document_index import DocumentIndexClient, SearchQuery
 
-client = DocumentIndexClient(token="<token>", base_document_index_url="<base_document_index_url>")
+client = DocumentIndexClient(token="<token>", base_url="<base_document_index_url>")
 
 namespaces = client.list_namespaces()
 collections = client.list_collections(namespaces[0])
@@ -34,12 +35,13 @@ client.search(collections[0], indexes[0].index, SearchQuery(query="What fish is 
 ```
 
 ### Retrievers
+
 ```python
 from pharia_data_sdk.connectors.retrievers.document_index_retriever import DocumentIndexRetriever
 from pharia_data_sdk.connectors.document_index.document_index import DocumentIndexClient
 
 retriever = DocumentIndexRetriever(
-    document_index=DocumentIndexClient(token="<token>", base_document_index_url="<base_document_index_url>"),
+    document_index=DocumentIndexClient(token="<token>", base_url="<base_document_index_url>"),
     index_name="<index_name>",
     namespace="<namespace>",
     collection="<collection>",

--- a/pharia_data_sdk/connectors/data/data.py
+++ b/pharia_data_sdk/connectors/data/data.py
@@ -48,14 +48,14 @@ class DataClient:
     def __init__(
         self,
         token: str | None,
-        base_url: str = "http://localhost:8000",
+        base_url: str,
         session: requests.Session | None = None,
     ) -> None:
         """Initialize the Data Client.
 
         Args:
             token: Access token
-            base_url: Base URL of the Studio Data API. Defaults to "http://localhost:8000".
+            base_url: Base URL of the Studio Data API.
             session: a already created requests session. Defaults to None.
         """
         self._base_url = f"{base_url.rstrip('/')}/"

--- a/pharia_data_sdk/connectors/data/data.py
+++ b/pharia_data_sdk/connectors/data/data.py
@@ -48,17 +48,17 @@ class DataClient:
     def __init__(
         self,
         token: str | None,
-        base_data_platform_url: str = "http://localhost:8000",
+        base_url: str = "http://localhost:8000",
         session: requests.Session | None = None,
     ) -> None:
         """Initialize the Data Client.
 
         Args:
             token: Access token
-            base_data_platform_url: Base URL of the Studio Data API. Defaults to "http://localhost:8000".
+            base_url: Base URL of the Studio Data API. Defaults to "http://localhost:8000".
             session: a already created requests session. Defaults to None.
         """
-        self._base_data_platform_url = base_data_platform_url
+        self._base_url = f"{base_url.rstrip('/')}/"
         self.headers = {
             **({"Authorization": f"Bearer {token}"} if token is not None else {}),
         }
@@ -83,6 +83,9 @@ class DataClient:
 
         warnings.warn("DataClient still in beta version and subject to change")
 
+    def __url(self, relative_path: str) -> str:
+        return urljoin(self._base_url, relative_path)
+
     def list_repositories(self, page: int = 0, size: int = 20) -> list[DataRepository]:
         """List all the repositories.
 
@@ -93,7 +96,7 @@ class DataClient:
         Returns:
             List of :class:`DataRepository` objects
         """
-        url = urljoin(self._base_data_platform_url, "api/v1/repositories")
+        url = self.__url("api/v1/repositories")
         query = urlencode({"page": page, "size": size})
         response = self._do_request("GET", f"{url}?{query}")
         repositories = response.json()
@@ -110,7 +113,7 @@ class DataClient:
         Returns:
             :class:`DataRepository` new object
         """
-        url = urljoin(self._base_data_platform_url, "api/v1/repositories")
+        url = self.__url("api/v1/repositories")
         response = self._do_request(
             "POST", url, json=repository.model_dump(by_alias=True)
         )
@@ -125,9 +128,7 @@ class DataClient:
         Returns:
             :class:`DataRepository` object
         """
-        url = urljoin(
-            self._base_data_platform_url, f"api/v1/repositories/{repository_id}"
-        )
+        url = self.__url(f"api/v1/repositories/{repository_id}")
         response = self._do_request("GET", url)
         return DataRepository(**response.json())
 
@@ -141,8 +142,7 @@ class DataClient:
         Returns:
             :class:`DataDataset` new object
         """
-        url = urljoin(
-            self._base_data_platform_url,
+        url = self.__url(
             f"api/v1/repositories/{repository_id}/datasets",
         )
         body = {
@@ -172,8 +172,7 @@ class DataClient:
         Returns:
             List of :class:`DataDataset` from a given repository
         """
-        url = urljoin(
-            self._base_data_platform_url,
+        url = self.__url(
             f"api/v1/repositories/{repository_id}/datasets",
         )
         query = urlencode({"page": page, "size": size})
@@ -191,8 +190,7 @@ class DataClient:
         Returns:
             :class:`DataDataset` object
         """
-        url = urljoin(
-            self._base_data_platform_url,
+        url = self.__url(
             f"api/v1/repositories/{repository_id}/datasets/{dataset_id}",
         )
         response = self._do_request("GET", url)
@@ -205,8 +203,7 @@ class DataClient:
             repository_id: Repository ID
             dataset_id: DataDataset ID
         """
-        url = urljoin(
-            self._base_data_platform_url,
+        url = self.__url(
             f"api/v1/repositories/{repository_id}/datasets/{dataset_id}",
         )
         self._do_request("DELETE", url)
@@ -221,8 +218,7 @@ class DataClient:
         Returns:
             :class Iterator of datapoints(Any)
         """
-        url = urljoin(
-            self._base_data_platform_url,
+        url = self.__url(
             f"api/v1/repositories/{repository_id}/datasets/{dataset_id}/datapoints",
         )
         response = self._do_request("GET", url, stream=True)
@@ -237,7 +233,7 @@ class DataClient:
         Returns:
             :class:`DataStage` new object
         """
-        url = urljoin(self._base_data_platform_url, "api/v1/stages")
+        url = self.__url("api/v1/stages")
         response = self._do_request("POST", url, json=stage.model_dump(by_alias=True))
         return DataStage(**response.json())
 
@@ -251,7 +247,7 @@ class DataClient:
         Returns:
             List of :class:`DataStage` objects
         """
-        url = urljoin(self._base_data_platform_url, "api/v1/stages")
+        url = self.__url("api/v1/stages")
         query = urlencode({"page": page, "size": size})
         response = self._do_request("GET", f"{url}?{query}")
         stages = response.json()
@@ -266,7 +262,7 @@ class DataClient:
         Returns:
             :class:`DataStage` object
         """
-        url = urljoin(self._base_data_platform_url, f"api/v1/stages/{stage_id}")
+        url = self.__url(f"api/v1/stages/{stage_id}")
         response = self._do_request("GET", url)
         return DataStage(**response.json())
 
@@ -280,8 +276,7 @@ class DataClient:
         Returns:
             :class:`DataFile` new object
         """
-        url = urljoin(
-            self._base_data_platform_url,
+        url = self.__url(
             f"api/v1/stages/{stage_id}/files",
         )
 
@@ -310,8 +305,7 @@ class DataClient:
         Returns:
             List of :class:`DataFile` objects
         """
-        url = urljoin(
-            self._base_data_platform_url,
+        url = self.__url(
             f"api/v1/stages/{stage_id}/files",
         )
         query = urlencode({"page": page, "size": size})
@@ -329,9 +323,7 @@ class DataClient:
         Returns:
             File bytes
         """
-        url = urljoin(
-            self._base_data_platform_url, f"api/v1/stages/{stage_id}/files/{file_id}"
-        )
+        url = self.__url(f"api/v1/stages/{stage_id}/files/{file_id}")
         response = self._do_request("GET", url)
         return io.BytesIO(response.content)
 

--- a/pharia_data_sdk/connectors/data/data.py
+++ b/pharia_data_sdk/connectors/data/data.py
@@ -47,7 +47,7 @@ class DataClient:
 
     def __init__(
         self,
-        token: str | None,
+        token: str,
         base_url: str,
         session: requests.Session | None = None,
     ) -> None:
@@ -59,9 +59,7 @@ class DataClient:
             session: a already created requests session. Defaults to None.
         """
         self._base_url = f"{base_url.rstrip('/')}/"
-        self.headers = {
-            **({"Authorization": f"Bearer {token}"} if token is not None else {}),
-        }
+        self.headers = {"Authorization": f"Bearer {token}"}
 
         self._session = session or requests.Session()
         retry_strategy = Retry(

--- a/pharia_data_sdk/connectors/document_index/document_index.py
+++ b/pharia_data_sdk/connectors/document_index/document_index.py
@@ -476,14 +476,14 @@ class DocumentIndexClient:
 
     def __init__(
         self,
-        token: str | None,
+        token: str,
         base_url: str,
     ) -> None:
         self._base_url = f"{base_url.rstrip('/')}/"
         self.headers = {
             "Content-Type": "application/json",
             "Accept": "application/json",
-            **({"Authorization": f"Bearer {token}"} if token is not None else {}),
+            "Authorization": f"Bearer {token}",
         }
 
     def __url(self, relative_path: str) -> str:
@@ -990,7 +990,7 @@ class AsyncDocumentIndexClient:
 
     def __init__(
         self,
-        token: str | None,
+        token: str,
         base_url: str,
     ) -> None:
         """Initializes an async client for the document index.
@@ -1003,7 +1003,7 @@ class AsyncDocumentIndexClient:
         self.headers = {
             "Content-Type": "application/json",
             "Accept": "application/json",
-            **({"Authorization": f"Bearer {token}"} if token is not None else {}),
+            "Authorization": f"Bearer {token}",
         }
         self._session: Optional[ClientSession] = None
 

--- a/pharia_data_sdk/connectors/document_index/document_index.py
+++ b/pharia_data_sdk/connectors/document_index/document_index.py
@@ -477,7 +477,7 @@ class DocumentIndexClient:
     def __init__(
         self,
         token: str | None,
-        base_url: str = "https://document-index.aleph-alpha.com",
+        base_url: str,
     ) -> None:
         self._base_url = f"{base_url.rstrip('/')}/"
         self.headers = {
@@ -991,7 +991,7 @@ class AsyncDocumentIndexClient:
     def __init__(
         self,
         token: str | None,
-        base_url: str = "https://document-index.aleph-alpha.com",
+        base_url: str,
     ) -> None:
         """Initializes an async client for the document index.
 

--- a/tests/conftest_document_index.py
+++ b/tests/conftest_document_index.py
@@ -45,17 +45,25 @@ R = TypeVar("R")
 
 
 @fixture(scope="session")
-def document_index(token: str) -> DocumentIndexClient:
-    return DocumentIndexClient(
-        token, base_document_index_url=os.environ["DOCUMENT_INDEX_URL"]
-    )
+def document_index_base_url() -> str:
+    try:
+        return os.environ["DOCUMENT_INDEX_URL"]
+    except KeyError:
+        raise Exception(
+            "Environment variable 'DOCUMENT_INDEX_URL' is not set."
+        ) from None
+
+
+@fixture(scope="session")
+def document_index(token: str, document_index_base_url: str) -> DocumentIndexClient:
+    return DocumentIndexClient(token, document_index_base_url)
 
 
 @pytest_asyncio.fixture()
-async def async_document_index(token: str) -> AsyncIterator[AsyncDocumentIndexClient]:
-    async with AsyncDocumentIndexClient(
-        token, base_document_index_url=os.environ["DOCUMENT_INDEX_URL"]
-    ) as client:
+async def async_document_index(
+    token: str, document_index_base_url: str
+) -> AsyncIterator[AsyncDocumentIndexClient]:
+    async with AsyncDocumentIndexClient(token, document_index_base_url) as client:
         yield client
 
 

--- a/tests/connectors/data/data/test_data.py
+++ b/tests/connectors/data/data/test_data.py
@@ -29,7 +29,9 @@ def mock_session() -> Mock:
 
 @pytest.fixture
 def data_client(mock_session: Mock) -> DataClient:
-    return DataClient(token="some-token", session=mock_session)
+    return DataClient(
+        token="some-token", base_url="http://localhost:8000", session=mock_session
+    )
 
 
 def test_list_repositories(data_client: DataClient, mock_session: Mock) -> None:

--- a/tests/connectors/document_index/test_async_document_index.py
+++ b/tests/connectors/document_index/test_async_document_index.py
@@ -29,9 +29,11 @@ pytestmark = pytest.mark.document_index
 
 
 @pytest.mark.internal
-def test_document_index_sets_authorization_header_for_given_token() -> None:
+def test_document_index_sets_authorization_header_for_given_token(
+    document_index_base_url: str,
+) -> None:
     token = "some-token"
-    async_document_index = AsyncDocumentIndexClient(token)
+    async_document_index = AsyncDocumentIndexClient(token, document_index_base_url)
     assert async_document_index.headers["Authorization"] == f"Bearer {token}"
 
 

--- a/tests/connectors/document_index/test_async_document_index.py
+++ b/tests/connectors/document_index/test_async_document_index.py
@@ -38,12 +38,6 @@ def test_document_index_sets_authorization_header_for_given_token(
 
 
 @pytest.mark.internal
-def test_document_index_sets_no_authorization_header_when_token_is_none() -> None:
-    async_document_index = AsyncDocumentIndexClient(None)
-    assert "Authorization" not in async_document_index.headers
-
-
-@pytest.mark.internal
 async def test_document_index_lists_namespaces_async(
     async_document_index: AsyncDocumentIndexClient,
     async_document_index_namespace: str,

--- a/tests/connectors/document_index/test_document_index.py
+++ b/tests/connectors/document_index/test_document_index.py
@@ -31,11 +31,11 @@ pytestmark = pytest.mark.document_index
 
 
 @pytest.mark.internal
-def test_document_index_sets_authorization_header_for_given_token() -> None:
+def test_document_index_sets_authorization_header_for_given_token(
+    document_index_base_url: str,
+) -> None:
     token = "some-token"
-
-    document_index = DocumentIndexClient(token)
-
+    document_index = DocumentIndexClient(token, document_index_base_url)
     assert document_index.headers["Authorization"] == f"Bearer {token}"
 
 

--- a/tests/connectors/document_index/test_document_index.py
+++ b/tests/connectors/document_index/test_document_index.py
@@ -40,13 +40,6 @@ def test_document_index_sets_authorization_header_for_given_token(
 
 
 @pytest.mark.internal
-def test_document_index_sets_no_authorization_header_when_token_is_none() -> None:
-    document_index = DocumentIndexClient(None)
-
-    assert "Authorization" not in document_index.headers
-
-
-@pytest.mark.internal
 def test_document_index_lists_namespaces(
     document_index: DocumentIndexClient,
     document_index_namespace: str,


### PR DESCRIPTION
This changeset addresses multiple issues with creating clients.

# Base URL with paths

Due to the way URL paths for API endpoints have been joined to the base URL, some endpoints wouldn't work if the base URL contained a path itself.

# Default value for `base_url`s

Setting a default base URL doesn't make sense for most of the target audience of this SDK.

# Required API Tokens

The document index isn't functional without providing an API token, so the token parameter shouldn't be optional.